### PR TITLE
Maintenance - 	Improve error message for unsupported SVN path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,13 @@
 /.gradle/
 /build/
 
-# IDE files
+# IDEA IDE files
 /*.iml
 /*.ipr
 /*.iws
+
+# Eclipse IDE files
+/bin/
+.classpath
+.project
+.settings/

--- a/src/main/groovy/at/bxm/gradleplugins/svntools/SvnSupport.groovy
+++ b/src/main/groovy/at/bxm/gradleplugins/svntools/SvnSupport.groovy
@@ -41,7 +41,7 @@ class SvnSupport {
           log.info "Working copy is on tag $result.tag at revision $result.revisionNumber"
         }
       } catch (MalformedURLException e) {
-        log.warning "SVN path has an unexpected layout: $e.message"
+        log.warning "Working copy must be a trunk, branches or tags folder: $e.message"
       }
     } catch (Exception e) {
       if (ignoreErrors) {


### PR DESCRIPTION
Hi Martin,  

I need SVN integration for my gradle projects and would prefer to use SVNKit rather than svnant, and I came across your project on GitHub. During trialling of the plugin I hit a few limitations and issues, which I'd like to get your feedback on. I will raise some issues for these separately.

In the meantime, this pull request is for a very minor improvement to an error message to clarify the cause of an error I hit when trialling the plugin. I mistakenly checked-out the root folder of the SVN project, rather than trunk. Although it was my mistake, I didn’t realise that at the time, and the cause wasn't obvious from the current error message - the reference to ‘layout’ initially made me think it was a problem with the version of the SVN workspace.

Thanks, 

Neil.