### PR TITLE
#8 Cosmetic improvement to error messages for SvnCheckout in cases where workspaceDir param not specified or directory exists.

### DIFF
--- a/src/main/groovy/at/bxm/gradleplugins/svntools/SvnCheckout.groovy
+++ b/src/main/groovy/at/bxm/gradleplugins/svntools/SvnCheckout.groovy
@@ -24,11 +24,11 @@ class SvnCheckout extends SvnBaseTask {
       throw new InvalidUserDataException("Invalid svnUrl value: $svnUrl", e)
     }
     if (!workspaceDir) {
-      throw new InvalidUserDataException("workspaceDir missing")
+      throw new InvalidUserDataException("workspaceDir must be specified")
     }
     def dir = workspaceDir instanceof File ? workspaceDir : workspaceDir.toString() as File
     if (dir.exists() && !(dir.isDirectory() && !dir.list())) {
-      throw new InvalidUserDataException("$dir.absolutePath must be an empty directory")
+      throw new InvalidUserDataException("workspaceDir $dir.absolutePath must be an empty directory")
     }
     try {
       createSvnClientManager().updateClient.doCheckout(repoUrl, dir, SVNRevision.UNDEFINED, rev, SVNDepth.INFINITY, false)

--- a/src/test/groovy/at/bxm/gradleplugins/svntools/SvnCheckoutTest.groovy
+++ b/src/test/groovy/at/bxm/gradleplugins/svntools/SvnCheckoutTest.groovy
@@ -63,6 +63,6 @@ class SvnCheckoutTest extends SvnTestSupport {
 
     then:
     def e = thrown TaskExecutionException
-    e.cause.message == "workspaceDir missing"
+    e.cause.message == "workspaceDir must be specified"
   }
 }


### PR DESCRIPTION
Hi Martin, 

I've tried out the new SvnCommit task and it's great. Thanks for the work. After your second round of commits (6387650) I only have one cosmetic suggestion - to refine the error messages for the error cases mentioned above. 

Neil.