### PR TITLE
Add functionality to tag dirty workspaces and keep the changes in the…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /*.iml
 /*.ipr
 /*.iws
+/*.idea
 
 # Eclipse IDE files
 /bin/

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 1.3.1-SNAPSHOT
+version = 1.3.1
 releaseNotes = #17 - SvnUpdate task added; SvnCheckout task now supports updates

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 1.3
+version = 1.3.1-SNAPSHOT
 releaseNotes = #17 - SvnUpdate task added; SvnCheckout task now supports updates

--- a/src/main/groovy/at/bxm/gradleplugins/svntools/internal/SvnCopy.groovy
+++ b/src/main/groovy/at/bxm/gradleplugins/svntools/internal/SvnCopy.groovy
@@ -67,10 +67,8 @@ abstract class SvnCopy extends SvnBaseTask {
     try {
       SVNInfo info = clientManager.WCClient.doInfo(workspace, SVNRevision.WORKING)
       if(localChanges) {
-        logger.error("FILE BASED")
         return [ copySource: new SVNCopySource(SVNRevision.WORKING, SVNRevision.WORKING, workspace), url: info.URL ]
       } else {
-        logger.error("REVISION BASED")
         return [copySource: new SVNCopySource(info.revision, info.revision, info.URL), url: info.URL]
       }
     } catch (SVNException e) {
@@ -92,7 +90,6 @@ abstract class SvnCopy extends SvnBaseTask {
 
   private SVNRepository remoteRepository(SVNURL repositoryUrl) {
     def repo = SVNRepositoryFactory.create(repositoryUrl)
-    logger.error("REMOTE BASED")
     repo.authenticationManager = SVNWCUtil.createDefaultAuthenticationManager(username, password)
     return repo
   }

--- a/src/main/groovy/at/bxm/gradleplugins/svntools/internal/SvnCopy.groovy
+++ b/src/main/groovy/at/bxm/gradleplugins/svntools/internal/SvnCopy.groovy
@@ -10,6 +10,7 @@ import org.tmatesoft.svn.core.io.SVNRepository
 import org.tmatesoft.svn.core.io.SVNRepositoryFactory
 import org.tmatesoft.svn.core.wc.SVNClientManager
 import org.tmatesoft.svn.core.wc.SVNCopySource
+import org.tmatesoft.svn.core.wc.SVNInfo
 import org.tmatesoft.svn.core.wc.SVNRevision
 import org.tmatesoft.svn.core.wc.SVNWCUtil
 
@@ -24,13 +25,17 @@ abstract class SvnCopy extends SvnBaseTask {
   /** If {@code true}, the target will be removed first if it already exists */
   boolean replaceExisting
 
+  /** If Local changes should be commited to the copy target. Only used it not svnUrl is provided. */
+  boolean localChanges
+
   abstract String getDestinationPath()
 
   @TaskAction
   def run() {
     def clientManager = createSvnClientManager()
-    def copySource = svnUrl ? fromRemote() : fromWorkspace(clientManager)
-    def sourceUrl = copySource.getURL()
+    def sourceInfo = svnUrl ? fromRemote() : fromWorkspace(clientManager)
+    def copySource = sourceInfo.copySource
+    def sourceUrl = sourceInfo.url
     def basePath = SvnPath.parse(sourceUrl).moduleBasePath
     def fullDestPath = "$basePath/$destinationPath"
     try {
@@ -57,23 +62,29 @@ abstract class SvnCopy extends SvnBaseTask {
     }
   }
 
-  private SVNCopySource fromWorkspace(SVNClientManager clientManager) {
+  private def fromWorkspace(SVNClientManager clientManager) {
     def workspace = workspaceDir ? project.file(workspaceDir, PathValidation.DIRECTORY) : project.projectDir
-    def info
     try {
-      info = clientManager.WCClient.doInfo(workspace, SVNRevision.WORKING)
+      SVNInfo info = clientManager.WCClient.doInfo(workspace, SVNRevision.WORKING)
+      if(localChanges) {
+        logger.error("FILE BASED")
+        return [ copySource: new SVNCopySource(SVNRevision.WORKING, SVNRevision.WORKING, workspace), url: info.URL ]
+      } else {
+        logger.error("REVISION BASED")
+        return [copySource: new SVNCopySource(info.revision, info.revision, info.URL), url: info.URL]
+      }
     } catch (SVNException e) {
       throw new InvalidUserDataException("svn-info failed for $workspace.absolutePath\n" + e.message, e)
     }
-    return new SVNCopySource(info.revision, info.revision, info.URL)
   }
 
-  private SVNCopySource fromRemote() {
+  private def fromRemote() {
     if (workspaceDir) {
       throw new InvalidUserDataException("Either 'svnUrl' or 'workspaceDir' may be set")
     }
     try {
-      return new SVNCopySource(SVNRevision.HEAD, SVNRevision.HEAD, SVNURL.parseURIEncoded(svnUrl))
+      SVNURL url = SVNURL.parseURIEncoded(svnUrl)
+      return [ copySource: new SVNCopySource(SVNRevision.HEAD, SVNRevision.HEAD, url), url: url ]
     } catch (SVNException e) {
       throw new InvalidUserDataException("Invalid svnUrl value: $svnUrl", e)
     }
@@ -81,6 +92,7 @@ abstract class SvnCopy extends SvnBaseTask {
 
   private SVNRepository remoteRepository(SVNURL repositoryUrl) {
     def repo = SVNRepositoryFactory.create(repositoryUrl)
+    logger.error("REMOTE BASED")
     repo.authenticationManager = SVNWCUtil.createDefaultAuthenticationManager(username, password)
     return repo
   }

--- a/src/test/groovy/at/bxm/gradleplugins/svntools/tasks/SvnTagDirty.groovy
+++ b/src/test/groovy/at/bxm/gradleplugins/svntools/tasks/SvnTagDirty.groovy
@@ -2,10 +2,6 @@ package at.bxm.gradleplugins.svntools.tasks
 
 import org.gradle.api.Project
 
-/*
- * Copyright (c) 2016 1&1 Mail & Media GmbH, Muenchen. All rights reserved.
- */
-
 /**
  * Do all the tests for SvnTag plus some extra ...
  */

--- a/src/test/groovy/at/bxm/gradleplugins/svntools/tasks/SvnTagDirty.groovy
+++ b/src/test/groovy/at/bxm/gradleplugins/svntools/tasks/SvnTagDirty.groovy
@@ -1,0 +1,59 @@
+package at.bxm.gradleplugins.svntools.tasks
+
+import org.gradle.api.Project
+
+/*
+ * Copyright (c) 2016 1&1 Mail & Media GmbH, Muenchen. All rights reserved.
+ */
+
+/**
+ * Do all the tests for SvnTag plus some extra ...
+ */
+class SvnTagDirty extends SvnTagTest {
+
+
+  def setup() {
+    task.localChanges = true
+  }
+
+  def "tag on dirty workspace" () {
+    given: "a dirty workspace"
+    workspace = checkoutTrunk()
+    def textFile = new File(workspace, "test.txt")
+    textFile.write("Dirty !")
+
+    when: "running the SvnTag task"
+    task.tagName = "dirty-tag"
+    task.workspaceDir = workspace
+    task.execute()
+
+    then: "tag contains changed file"
+    workspace.deleteDir()
+    def tag = checkoutLocalRepo("tags/dirty-tag")
+    def branchFile = new File(tag, "test.txt")
+    branchFile.text == "Dirty !"
+    tag.deleteDir()
+    def cleanWorkspace = checkoutTrunk()
+    def cleanFile = new File(cleanWorkspace, "test.txt")
+    cleanFile.text == ""
+  }
+
+  def "clean tag on dirty workspace" () {
+    given: "a dirty workspace"
+    workspace = checkoutTrunk()
+    def textFile = new File(workspace, "test.txt")
+    textFile.write("Dirty !")
+
+    when: "running the SvnTag task without local changes"
+    task.tagName = "clean-tag"
+    task.localChanges = false
+    task.workspaceDir = workspace
+    task.execute()
+
+    then: "tag does not contain changed file"
+    workspace.deleteDir()
+    def tag = checkoutLocalRepo("tags/clean-tag")
+    def branchFile = new File(tag, "test.txt")
+    branchFile.text == ""
+  }
+}


### PR DESCRIPTION
For my continuous integration pipeline I need the functionality to tag a workspace with modified files (the version information of the project) without committing this modifications to the trunk. SVNkit can easily do this, but the gradle plugin lacks the API for that.

So I added it. 

You now can configure the property "localChanges" on any copy task an d if you tag a local workspace woth this property set to "true" the modified files will be committed to the tag 