### PR TITLE
Bump svn library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ group = "at.bxm.gradleplugins"
 
 dependencies {
   compile "org.codehaus.groovy:groovy-all:2.3.6"
-  compile "org.tmatesoft.svnkit:svnkit:1.8.5"
+  compile "org.tmatesoft.svnkit:svnkit:1.8.12"
   testCompile("org.spockframework:spock-core:0.7-groovy-2.0") {
     exclude group: "org.codehaus.groovy"
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 1.6
+version = 1.6.1
 releaseNotes = "svn-export" support added; "svn-checkout": depth option added; check status of remote SVN URLs

--- a/src/main/groovy/at/bxm/gradleplugins/svntools/internal/SvnSupport.groovy
+++ b/src/main/groovy/at/bxm/gradleplugins/svntools/internal/SvnSupport.groovy
@@ -31,7 +31,7 @@ class SvnSupport {
     def authManager = new BasicAuthenticationManager(username, password)
     if (proxy?.host) {
       log.info "Using proxy $proxy"
-      authManager.setProxy(proxy.host, proxy.port, proxy.username, proxy.password)
+      authManager.setProxy(proxy.host, proxy.port, proxy.username, (String)proxy.password)
     }
     return authManager
   }


### PR DESCRIPTION
Please update to latest svn library, as v1.8.5 seems to have problems with svn via https (at least in our company's setup).

svnkit version bumped to latest version, fixed method ambiguity introduced by updated svn library. Plugin version updated to 1.6.1.