### PR TITLE
GroovyRuntimeException with no password for network proxy

### DIFF
--- a/docs/GeneralConfig.md
+++ b/docs/GeneralConfig.md
@@ -15,7 +15,7 @@ The `svntools` block (implemented by [SvnToolsPluginExtension](../src/main/groov
     * **info.branch** "true" if the SVN URL refers to a branch
     * **info.tag** "true" if the SVN URL refers to a tag
 * access information about an arbitrary path within an SVN workspace, wrapped by an [SvnData](../src/main/groovy/at/bxm/gradleplugins/svntools/api/SvnData.groovy) object: **getInfo("path/file.ext")** (see example below)
-* access information about a path within a remote SVN repository, wrapped by an [SvnData](../src/main/groovy/at/bxm/gradleplugins/svntools/api/SvnData.groovy) object: **getRemoteInfo("", "path/file.ext")** (see example below)
+* access information about a path within a remote SVN repository, wrapped by an [SvnData](../src/main/groovy/at/bxm/gradleplugins/svntools/api/SvnData.groovy) object: **getRemoteInfo("repoUrl","path/file.ext")** (see example below)
 * summarize the local revision(s) of a working copy, wrapped by an [SvnVersionData](../src/main/groovy/at/bxm/gradleplugins/svntools/api/SvnVersionData.groovy) object:
     * **version** [svnversion](http://svnbook.red-bean.com/en/1.7/svn.ref.svnversion.re.html) output
     * **version.mixedRevision** "true" if the working copy contains mixed revisions

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version = 1.6.1
-releaseNotes = "svn-export" support added; "svn-checkout": depth option added; check status of remote SVN URLs
+releaseNotes = Bump svn library version

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version = 1.6-SNAPSHOT
-releaseNotes = ...
+version = 1.6
+releaseNotes = "svn-export" support added; "svn-checkout": depth option added; check status of remote SVN URLs

--- a/src/main/groovy/at/bxm/gradleplugins/svntools/internal/SvnSupport.groovy
+++ b/src/main/groovy/at/bxm/gradleplugins/svntools/internal/SvnSupport.groovy
@@ -31,7 +31,7 @@ class SvnSupport {
     def authManager = new BasicAuthenticationManager(username, password)
     if (proxy?.host) {
       log.info "Using proxy $proxy"
-      authManager.setProxy(proxy.host, proxy.port, proxy.username, (String)proxy.password)
+      authManager.setProxy(proxy.host, proxy.port, proxy.username, proxy.password as String)
     }
     return authManager
   }


### PR DESCRIPTION
Modified cast to avoid GroovyRuntimeException when using a proxy without username/password due to overlapping prototypes in BasicAuthenticationManager.getProxy methods.

Caused by: groovy.lang.GroovyRuntimeException: Ambiguous method overloading for method org.tmatesoft.svn.core.auth.BasicAuthenticationManager#setProxy.
Cannot resolve which method to invoke for [class java.lang.String, class java.lang.Integer, null, null] due to overlapping prototypes between:
 [class java.lang.String, int, class java.lang.String, class [C]
        [class java.lang.String, int, class java.lang.String, class java.lang.String]
        at groovy.lang.MetaClassImpl.chooseMostSpecificParams(MetaClassImpl.java:3241)
        at groovy.lang.MetaClassImpl.chooseMethodInternal(MetaClassImpl.java:3194)
        at groovy.lang.MetaClassImpl.chooseMethod(MetaClassImpl.java:3137)
        at groovy.lang.MetaClassImpl.getMethodWithCachingInternal(MetaClassImpl.java:1328)
        at groovy.lang.MetaClassImpl.createPojoCallSite(MetaClassImpl.java:3370)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.createPojoSite(CallSiteArray.java:132)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.createCallSite(CallSiteArray.java:166)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:149)
        at at.bxm.gradleplugins.svntools.internal.SvnSupport.createAuthenticationManager(SvnSupport.groovy:34)
        at at.bxm.gradleplugins.svntools.internal.SvnSupport$createAuthenticationManager$1.callStatic(UnknownSource)
        at at.bxm.gradleplugins.svntools.internal.SvnSupport.createSvnClientManager(SvnSupport.groovy:27)
        at at.bxm.gradleplugins.svntools.internal.SvnSupport$createSvnClientManager$0.callStatic(UnknownSource)
        at at.bxm.gradleplugins.svntools.internal.SvnSupport.createSvnData(SvnSupport.groovy:42)