### PR TITLE
Add task types as extensions so that they can be used in buildscripts

### DIFF
--- a/src/main/groovy/at/bxm/gradleplugins/svntools/SvnToolsPlugin.groovy
+++ b/src/main/groovy/at/bxm/gradleplugins/svntools/SvnToolsPlugin.groovy
@@ -1,11 +1,27 @@
 package at.bxm.gradleplugins.svntools
 
-import org.gradle.api.*
+import at.bxm.gradleplugins.svntools.tasks.*
+import org.gradle.api.Plugin
+import org.gradle.api.Project
 
 class SvnToolsPlugin implements Plugin<Project> {
 
   @Override
   void apply(Project project) {
     project.extensions.create("svntools", SvnToolsPluginExtension, project)
+    project.extensions.extraProperties.set("SvnAdd", SvnAdd.class)
+    project.extensions.extraProperties.set("SvnApplyPatch", SvnApplyPatch.class)
+    project.extensions.extraProperties.set("SvnBranch", SvnBranch.class)
+    project.extensions.extraProperties.set("SvnCheckout", SvnCheckout.class)
+    project.extensions.extraProperties.set("SvnCleanup", SvnCleanup.class)
+    project.extensions.extraProperties.set("SvnCommit", SvnCommit.class)
+    project.extensions.extraProperties.set("SvnCreatePatch", SvnCreatePatch.class)
+    project.extensions.extraProperties.set("SvnDelete", SvnDelete.class)
+    project.extensions.extraProperties.set("SvnExport", SvnExport.class)
+    project.extensions.extraProperties.set("SvnInfo", SvnInfo.class)
+    project.extensions.extraProperties.set("SvnRevert", SvnRevert.class)
+    project.extensions.extraProperties.set("SvnTag", SvnTag.class)
+    project.extensions.extraProperties.set("SvnUpdate", SvnUpdate.class)
+    project.extensions.extraProperties.set("SvnVersion", SvnVersion.class)
   }
 }

--- a/src/test/groovy/at/bxm/gradleplugins/svntools/SvnToolsPluginTest.groovy
+++ b/src/test/groovy/at/bxm/gradleplugins/svntools/SvnToolsPluginTest.groovy
@@ -15,7 +15,7 @@ class SvnToolsPluginTest extends SvnTestSupport {
   def "Tasks are available by name"(String name, Class<?> taskClass) {
     expect:
     def project = projectWithPlugin()
-    def task = project.task(type: project.extensions.extraProperties.get(name), name.toLowerCase())
+    def task = project.task(type: project."${name}", name.toLowerCase())
     task in taskClass
 
     where:

--- a/src/test/groovy/at/bxm/gradleplugins/svntools/SvnToolsPluginTest.groovy
+++ b/src/test/groovy/at/bxm/gradleplugins/svntools/SvnToolsPluginTest.groovy
@@ -1,5 +1,7 @@
 package at.bxm.gradleplugins.svntools
 
+import at.bxm.gradleplugins.svntools.tasks.*
+
 class SvnToolsPluginTest extends SvnTestSupport {
 
   def "apply plugin"() {
@@ -8,5 +10,29 @@ class SvnToolsPluginTest extends SvnTestSupport {
 
     then: "extension is defined"
     project.extensions.getByType(SvnToolsPluginExtension)
+  }
+
+  def "Tasks are available by name"(String name, Class<?> taskClass) {
+    expect:
+    def project = projectWithPlugin()
+    def task = project.task(type: project.extensions.extraProperties.get(name), name.toLowerCase())
+    task in taskClass
+
+    where:
+    name             | taskClass
+    'SvnAdd'         | SvnAdd.class
+    'SvnApplyPatch'  | SvnApplyPatch.class
+    'SvnBranch'      | SvnBranch.class
+    'SvnCheckout'    | SvnCheckout.class
+    'SvnCleanup'     | SvnCleanup.class
+    'SvnCommit'      | SvnCommit.class
+    'SvnCreatePatch' | SvnCreatePatch.class
+    'SvnDelete'      | SvnDelete.class
+    'SvnExport'      | SvnExport.class
+    'SvnInfo'        | SvnInfo.class
+    'SvnRevert'      | SvnRevert.class
+    'SvnTag'         | SvnTag.class
+    'SvnUpdate'      | SvnUpdate.class
+    'SvnVersion'     | SvnVersion.class
   }
 }


### PR DESCRIPTION
This makes the task types available by name, so that it's possible to do:

```groovy
task myTag(type: SvnTag) {
    tagName = 'foo'
    svnUrl = 'https://svn.example.com/projects/example/trunk'
    commitMessage = 'A new tag!'
    username = 'mark'
    password = 'SuperSecret'
}
```